### PR TITLE
fix: Add stdin UTF-8 reconfiguration to resolve encoding issues on Wi…

### DIFF
--- a/src/mcp_server_everything_search/server.py
+++ b/src/mcp_server_everything_search/server.py
@@ -317,21 +317,34 @@ def configure_windows_console():
     import ctypes
 
     if sys.platform == "win32":
-        # Enable virtual terminal processing
-        kernel32 = ctypes.windll.kernel32
-        STD_OUTPUT_HANDLE = -11
-        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+        try:
+            # Enable virtual terminal processing
+            kernel32 = ctypes.windll.kernel32
+            STD_OUTPUT_HANDLE = -11
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+            
+            handle = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+            mode = ctypes.c_ulong()
+            kernel32.GetConsoleMode(handle, ctypes.byref(mode))
+            mode.value |= ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            kernel32.SetConsoleMode(handle, mode)
+        except (OSError, AttributeError, TypeError) as e:
+            sys.stderr.write(f"Warning: Failed to enable virtual terminal processing: {e}\n")
         
-        handle = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
-        mode = ctypes.c_ulong()
-        kernel32.GetConsoleMode(handle, ctypes.byref(mode))
-        mode.value |= ENABLE_VIRTUAL_TERMINAL_PROCESSING
-        kernel32.SetConsoleMode(handle, mode)
-        
-        # Set UTF-8 encoding for console I/O
-        sys.stdout.reconfigure(encoding='utf-8')
-        sys.stderr.reconfigure(encoding='utf-8')
-        sys.stdin.reconfigure(encoding='utf-8')
+        # Attempt to set UTF-8 encoding for all standard streams
+        for name, stream in [("stdin", sys.stdin), ("stdout", sys.stdout), ("stderr", sys.stderr)]:
+            # Skip if already UTF-8
+            current_enc = getattr(stream, 'encoding', None)
+            if current_enc == 'utf-8':
+                continue
+            if hasattr(stream, 'reconfigure'):
+                try:
+                    stream.reconfigure(encoding='utf-8')
+                except Exception as e:
+                    # Log to stderr (which might still be ASCII, but safe)
+                    sys.stderr.write(f"Warning: Failed to set UTF-8 for {name}: {e}\n")
+            else:
+                sys.stderr.write(f"Warning: {name} does not support reconfigure, encoding may not be UTF-8\n")
 
 def main() -> None:
     """Main entry point."""

--- a/src/mcp_server_everything_search/server.py
+++ b/src/mcp_server_everything_search/server.py
@@ -313,7 +313,7 @@ Search Syntax Guide:
         await server.run(read_stream, write_stream, options, raise_exceptions=True)
 
 def configure_windows_console():
-    """Configure Windows console for UTF-8 output."""
+    """Configure Windows console for UTF-8 input and output."""
     import ctypes
 
     if sys.platform == "win32":
@@ -328,9 +328,10 @@ def configure_windows_console():
         mode.value |= ENABLE_VIRTUAL_TERMINAL_PROCESSING
         kernel32.SetConsoleMode(handle, mode)
         
-        # Set UTF-8 encoding for console output
+        # Set UTF-8 encoding for console I/O
         sys.stdout.reconfigure(encoding='utf-8')
         sys.stderr.reconfigure(encoding='utf-8')
+        sys.stdin.reconfigure(encoding='utf-8')
 
 def main() -> None:
     """Main entry point."""


### PR DESCRIPTION
# Related Issues

Fixes #27 

# Description

When running the MCP server `mcp-server-everything-search` from source using `uv run` (as configured in MCP client settings), search queries containing non-ASCII characters (e.g., Chinese, accented letters, emoji) return an empty result. However, the same server installed from PyPI and run via `uvx` handles such queries correctly.

Debugging reveals that when the server is launched by the MCP client (which redirects `stdin`/`stdout` to pipes), Python's `sys.stdin.encoding` defaults to the system locale encoding (`'gbk'` on Chinese Windows) instead of `'utf-8'`. This causes the UTF-8 encoded JSON‑RPC request (which may contain any Unicode characters) to be decoded incorrectly, resulting in garbled query strings and therefore no search results.

The source code currently only configures `stdout` and `stderr` to use UTF-8 (via `sys.stdout.reconfigure(encoding='utf-8')` in `configure_windows_console()`), but leaves `stdin` untouched. Explicitly setting stdin to UTF-8 resolves the issue for all non-ASCII input.

## Example

**Input Query:** `酷狗` (Chinese) or `Ñoño` (Spanish) or `Привет` (Russian)  
**Debug Output Shows:** `閰风嫍` or other garbled text

```json
{
  "method": "notifications/message",
  "params": {
    "level": "debug",
    "logger": "stdio",
    "data": {
      "message": "Debug: Setting up search with query: 閰风嫍，stdin encoding: gbk, stdout encoding: utf-8, default encoding: utf-8"
    }
  }
}
```

## Environment

- **OS:** Windows (any version with non-UTF8 default code page)
- **Shell:** PowerShell 7, CMD, or other Windows consoles
- **Python:** UTF-8 default encoding
- **Affected Systems:** Any Windows system where active code page ≠ UTF-8

# Solution

Explicitly set `stdin` encoding to UTF‑8 in `configure_windows_console()`.

This fix makes the server robust regardless of how it is launched (source, installed, or via uvx), and works for all non‑ASCII input.
