### PR TITLE
Fix sort_by Parameter Schema and Validation Issues #16 #26

### DIFF
--- a/src/mcp_server_everything_search/platform_search.py
+++ b/src/mcp_server_everything_search/platform_search.py
@@ -1,8 +1,7 @@
 """Platform-specific search implementations with dedicated parameter models."""
 
-from typing import Optional, List, Dict, Any, Literal
+from typing import Optional, List, Dict, Any, Literal, get_args
 from pydantic import BaseModel, Field
-from enum import Enum
 import platform
 
 class BaseSearchQuery(BaseModel):
@@ -70,7 +69,19 @@ WINDOWS_SORT_OPTIONS = {
     14: "Modified Date Descending",
 }
 
-WindowsSortOption = Literal[tuple(WINDOWS_SORT_OPTIONS.keys())]
+# Define Literal type explicitly for MCP Inspector form compatibility
+WindowsSortOption = Literal[1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14]
+
+# Runtime validation: ensure Literal values match dictionary keys
+_literal_values = set(get_args(WindowsSortOption))
+_dict_keys = set(WINDOWS_SORT_OPTIONS.keys())
+
+if _literal_values != _dict_keys:
+    raise RuntimeError(
+        f"INTERNAL ERROR: WindowsSortOption Literal values ({sorted(_literal_values)}) "
+        f"do not match WINDOWS_SORT_OPTIONS keys ({sorted(_dict_keys)}). "
+        "Please update WindowsSortOption to match the dictionary keys."
+    )
 
 _sort_descriptions = "; ".join([f"{k}={v}" for k, v in WINDOWS_SORT_OPTIONS.items()])
 

--- a/src/mcp_server_everything_search/platform_search.py
+++ b/src/mcp_server_everything_search/platform_search.py
@@ -1,6 +1,6 @@
 """Platform-specific search implementations with dedicated parameter models."""
 
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Literal
 from pydantic import BaseModel, Field
 from enum import Enum
 import platform
@@ -55,20 +55,7 @@ class LinuxSpecificParams(BaseModel):
         description="Only display count of matches (-c parameter)"
     )
 
-class WindowsSortOption(int, Enum):
-    """Sort options for Windows Everything search."""
-    NAME_ASC = 1
-    NAME_DESC = 2
-    PATH_ASC = 3
-    PATH_DESC = 4
-    SIZE_ASC = 5
-    SIZE_DESC = 6
-    EXT_ASC = 7
-    EXT_DESC = 8
-    CREATED_ASC = 11
-    CREATED_DESC = 12
-    MODIFIED_ASC = 13
-    MODIFIED_DESC = 14
+WindowsSortOption = Literal[1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14]
 
 class WindowsSpecificParams(BaseModel):
     """Windows-specific search parameters for Everything SDK."""
@@ -89,8 +76,8 @@ class WindowsSpecificParams(BaseModel):
         description="Enable regex search"
     )
     sort_by: WindowsSortOption = Field(
-        default=WindowsSortOption.NAME_ASC,
-        description="Sort order for results"
+        default=1,
+        description="Sort order for results. 1: NAME ASC, 2: NAME DESC, 3: PATH ASC, 4: PATH DESC, 5: SIZE ASC, 6: SIZE DESC, 7: EXT ASC, 8: EXT DESC, 11: CREATED ASC, 12: CREATED DESC, 13: MODIFIED ASC, 14: MODIFIED DESC"
     )
 
 class UnifiedSearchQuery(BaseSearchQuery):

--- a/src/mcp_server_everything_search/platform_search.py
+++ b/src/mcp_server_everything_search/platform_search.py
@@ -55,7 +55,24 @@ class LinuxSpecificParams(BaseModel):
         description="Only display count of matches (-c parameter)"
     )
 
-WindowsSortOption = Literal[1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14]
+WINDOWS_SORT_OPTIONS = {
+    1: "Name Ascending",
+    2: "Name Descending",
+    3: "Path Ascending",
+    4: "Path Descending",
+    5: "Size Ascending",
+    6: "Size Descending",
+    7: "Extension Ascending",
+    8: "Extension Descending",
+    11: "Created Date Ascending",
+    12: "Created Date Descending",
+    13: "Modified Date Ascending",
+    14: "Modified Date Descending",
+}
+
+WindowsSortOption = Literal[tuple(WINDOWS_SORT_OPTIONS.keys())]
+
+_sort_descriptions = "; ".join([f"{k}={v}" for k, v in WINDOWS_SORT_OPTIONS.items()])
 
 class WindowsSpecificParams(BaseModel):
     """Windows-specific search parameters for Everything SDK."""
@@ -77,7 +94,7 @@ class WindowsSpecificParams(BaseModel):
     )
     sort_by: WindowsSortOption = Field(
         default=1,
-        description="Sort order for results. 1: NAME ASC, 2: NAME DESC, 3: PATH ASC, 4: PATH DESC, 5: SIZE ASC, 6: SIZE DESC, 7: EXT ASC, 8: EXT DESC, 11: CREATED ASC, 12: CREATED DESC, 13: MODIFIED ASC, 14: MODIFIED DESC"
+        description=f"Sort order for results. {_sort_descriptions}"
     )
 
 class UnifiedSearchQuery(BaseSearchQuery):


### PR DESCRIPTION
# Summary

This PR fixes critical issues with the `windows_params.sort_by` parameter that prevented MCP clients from successfully calling the search tool.

# Related Issues

- Fixes #16
- Fixes #21
- Fixes #26
- Supersedes PR #18 (which attempted but failed to fix the issue)

# Problems Solved

## Problem 1: JSON Schema `$defs` Reference Error ❌

**Symptom:** MCP clients (including AI Agents, LM Studio,Gemini CLI,Cherry Studio,etc) received schema validation errors when explicitly setting the `sort_by` parameter:

```
PointerToNowhere: '/$defs/WindowsSortOption' does not exist within {...}
```

**Root Cause:** The original code used an `Enum` type for `sort_by`, which caused Pydantic to generate a JSON Schema with nested `$defs` references. Many MCP clients cannot resolve these references, leading to tool call failures.

**Why PR #18 Failed:** That PR attempted to manually inject `$defs` into the schema, but this approach still relied on `$ref` references, which MCP clients continue to reject (as reported in the comments).

## Problem 2: Missing Semantic Information for Clients ⚠️

**Symptom:** Even when calls succeeded (by omitting `sort_by`), MCP clients had no information about what each enum value means (e.g., `1` = Name Ascending, `2` = Name Descending).

**Impact:** 
- AI Agents couldn't make informed decisions about sort options
- No validation feedback for users

# Root Cause Analysis

The related issues (#16, #21,#26) only reported error messages without identifying the specific problematic parameter. Through systematic debugging using MCP Inspector, I discovered:

1. **Parameter Identification:** The `sort_by` field was the root cause - calls failed only when this parameter was explicitly set
2. **Schema Structure Issue:** Pydantic's Enum-based schema generation creates `$ref` dependencies that MCP clients can't resolve
3. **Missing Documentation:** The second issue - semantic information about sort values wasn't exposed to clients at all

# Solution

## Approach: Single Source of Truth with Dictionary + Explicit Literal Type

```python
# Define canonical data source (single source of truth)
WINDOWS_SORT_OPTIONS = {
    1: "Name Ascending",
    2: "Name Descending",
    3: "Path Ascending",
    # ... etc
}

# Define Literal type explicitly for MCP Inspector form compatibility
# Keep in sync with WINDOWS_SORT_OPTIONS keys (validated at runtime)
WindowsSortOption = Literal[1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14]

# Auto-generate description from dictionary
_sort_descriptions = "; ".join([f"{k}={v}" for k, v in WINDOWS_SORT_OPTIONS.items()])

sort_by: WindowsSortOption = Field(
    default=1,
    description=f"Sort order for results. {_sort_descriptions}"
)
```

**Implementation Notes:**
- Initially attempted to use `TypeAliasType` for dynamic generation, but MCP Inspector's form generator couldn't handle it
- Final solution uses explicit Literal definition for maximum compatibility
- Added runtime validation to ensure Literal values stay in sync with dictionary keys

# Changes

- Replaced `Enum` type with explicit `Literal` union for better MCP client compatibility
- Added comprehensive parameter descriptions including all sort options
- Eliminated schema complexity that caused client incompatibility
- Implemented runtime validation to maintain consistency between Literal and dictionary
- Improved code maintainability through single-source-of-truth pattern

## Benefits

✅ **Flat JSON Schema:** Explicit `Literal` type generates inline `enum` without `$defs` or `$ref` - compatible with all MCP clients including form generators  
✅ **Single Source of Truth:** Dictionary serves as canonical reference for sort options and descriptions  
✅ **Automatic Documentation:** Description auto-generated from dictionary values  
✅ **Preserved Validation:** Pydantic validates enum values at runtime (same as before, but with better schema)  
✅ **Maintainable:** Runtime validation ensures Literal stays in sync with dictionary  
✅ **MCP Inspector Compatible:** Form mode correctly displays `sort_by` parameter with all options  

### Why Literal Instead of Enum?

Both `Enum` and `Literal` work with Pydantic for runtime validation. The key difference is **JSON Schema generation**:

| Aspect | Enum Approach | Literal Approach |
|--------|--------------|------------------|
| **Schema Structure** | ❌ Creates nested `$defs` with `$ref` references | ✅ Generates flat inline `enum` in schema |
| **MCP Client Compatibility** | ❌ Many clients fail to resolve `$ref` (LM Studio, AI Agents) | ✅ Universal compatibility - no reference resolution needed |
| **Type Complexity** | ❌ Requires separate type definition and value mapping | ✅ Type is the values - no indirection |
| **Runtime Validation** | ✅ Pydantic validates (already worked before) | ✅ Pydantic validates (same validation, different schema) |
| **Code Usage** | ✅ Semantic names (`WindowsSortOption.NAME_ASC`) | ⚠️ Raw values (`1`) - mitigated by dictionary constants |

# Testing

Verified with:
- ✅ MCP Inspector: Can now send `sort_by` parameter without errors
- ✅ Schema inspection: Flat structure without `$defs`
- ✅ AI Agents: Can now use `sort_by` parameter without errors
