### PR TITLE
Fix unusable search tool: hoist nested $defs so $ref pointers resolve

### DIFF
--- a/src/mcp_server_everything_search/platform_search.py
+++ b/src/mcp_server_everything_search/platform_search.py
@@ -103,23 +103,37 @@ class UnifiedSearchQuery(BaseSearchQuery):
     def get_schema_for_platform(cls) -> Dict[str, Any]:
         """Get the appropriate schema based on the current platform."""
         system = platform.system().lower()
-        
+
         schema = {
             "type": "object",
-            "properties": {
-                "base": BaseSearchQuery.model_json_schema()
-            },
-            "required": ["base"]
+            "properties": {},
+            "required": ["base"],
         }
-        
+        # Collected $defs from every nested sub-schema, hoisted to the root so
+        # that "#/$defs/..." $ref pointers resolve against the document root as
+        # required by JSON Schema. Pydantic emits these $defs inside each
+        # sub-model's schema; leaving them nested produces dangling pointers
+        # (PointerToNowhere) when an MCP client validates the tool input.
+        root_defs: Dict[str, Any] = {}
+
+        def add_property(name: str, model) -> None:
+            sub = model.model_json_schema()
+            root_defs.update(sub.pop("$defs", {}))
+            schema["properties"][name] = sub
+
+        add_property("base", BaseSearchQuery)
+
         # Add platform-specific parameters
         if system == "darwin":
-            schema["properties"]["mac_params"] = MacSpecificParams.model_json_schema()
+            add_property("mac_params", MacSpecificParams)
         elif system == "linux":
-            schema["properties"]["linux_params"] = LinuxSpecificParams.model_json_schema()
+            add_property("linux_params", LinuxSpecificParams)
         elif system == "windows":
-            schema["properties"]["windows_params"] = WindowsSpecificParams.model_json_schema()
-            
+            add_property("windows_params", WindowsSpecificParams)
+
+        if root_defs:
+            schema["$defs"] = root_defs
+
         return schema
 
     def get_platform_params(self) -> Optional[BaseModel]:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,48 @@
+"""Regression tests for the platform tool-input schema.
+
+Covers the bug where Pydantic emitted the ``WindowsSortOption`` enum as a
+``$ref`` to a ``$defs`` block nested *inside* ``windows_params``. A JSON
+Schema ``$ref`` of ``#/$defs/...`` resolves from the document root, so the
+nested placement left a dangling pointer and MCP clients rejected the tool
+input with ``PointerToNowhere``.
+"""
+
+from mcp_server_everything_search.platform_search import UnifiedSearchQuery
+
+
+def _iter_refs(node):
+    """Yield every ``$ref`` string found anywhere in a schema fragment."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_refs(item)
+
+
+def _resolve(root, ref):
+    """Resolve a ``#/a/b/c`` JSON pointer against the document root."""
+    assert ref.startswith("#/"), f"unexpected $ref form: {ref}"
+    target = root
+    for part in ref[2:].split("/"):
+        target = target[part]  # KeyError here == dangling pointer
+    return target
+
+
+def test_all_refs_resolve_against_root():
+    """Every $ref in the generated schema must resolve from the root."""
+    schema = UnifiedSearchQuery.get_schema_for_platform()
+    refs = list(_iter_refs(schema))
+    for ref in refs:
+        # Must not raise -- a dangling pointer is exactly the original bug.
+        _resolve(schema, ref)
+
+
+def test_defs_are_hoisted_to_root():
+    """Nested $defs must be lifted to the root, none left inside properties."""
+    schema = UnifiedSearchQuery.get_schema_for_platform()
+    for name, prop in schema["properties"].items():
+        assert "$defs" not in prop, f"{name} still carries a nested $defs"


### PR DESCRIPTION
## Problem

The `search` tool is rejected by MCP clients that validate tool input, with a `PointerToNowhere` error, whenever the input schema is checked. This makes the Windows `sort_by` parameter effectively unusable.

### Root cause

`WindowsSpecificParams.sort_by` is typed as the `WindowsSortOption` enum. Pydantic renders it as:

```json
"sort_by": { "$ref": "#/$defs/WindowsSortOption", ... }
```

…with the matching `$defs` block nested **inside** the `windows_params` sub-schema. Per the JSON Schema spec, a `#/$defs/...` pointer resolves from the **document root**. Because `get_schema_for_platform()` inlines each sub-model's `model_json_schema()` (including its private `$defs`) without lifting those definitions to the root, the pointer dangles and validators raise `PointerToNowhere`.

Reproduced on a live MCP client:

```
PointerToNowhere: '/$defs/WindowsSortOption' does not exist within { ... 'required': ['base'] }
```

## Fix

Collect every sub-model's `$defs` and hoist them to the root of the schema returned by `get_schema_for_platform()`. The fix is generic — it handles any nested `$ref` on any platform — and leaves the public tool interface unchanged.

## Tests

Adds `tests/test_schema.py` with two regression tests:
- every `$ref` in the generated schema resolves from the document root
- no sub-schema retains a nested `$defs`

Both fail against the current code and pass with the fix.

```
tests/test_schema.py::test_all_refs_resolve_against_root PASSED
tests/test_schema.py::test_defs_are_hoisted_to_root PASSED
```

Verified end-to-end against a real Everything index: `sort_by=6` (size descending) now returns correctly-ordered results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)